### PR TITLE
refactor: apply DRY and SRP principles to parser services

### DIFF
--- a/recruitment_qualification_test-main/app/services/base_parser_service.rb
+++ b/recruitment_qualification_test-main/app/services/base_parser_service.rb
@@ -1,0 +1,20 @@
+class BaseParserService
+  attr_reader :data
+
+  def initialize(data, listing_creator = ListingCreator)
+    @data = data
+    @listing_creator = listing_creator
+  end
+
+  def parse
+    extract_listings.each do |listing_data|
+      @listing_creator.create(listing_data)
+    end
+  end
+
+  private
+
+  def extract_listings
+    raise NotImplementedError, "Subclasses must implement extract_listings method"
+  end
+end

--- a/recruitment_qualification_test-main/app/services/listing_creator.rb
+++ b/recruitment_qualification_test-main/app/services/listing_creator.rb
@@ -1,0 +1,21 @@
+class ListingCreator
+  def self.create(listing_data)
+    attributes = listing_data.respond_to?(:to_h) ? listing_data.to_h : listing_data
+    
+    Listing.create!({
+      title: attributes[:title],
+      start_time: attributes[:start_time],
+      end_time: attributes[:end_time],
+      description: attributes[:description],
+      image_url: attributes[:image_url],
+      episode_number: normalize_number(attributes[:episode_number]),
+      season_number: normalize_number(attributes[:season_number])
+    })
+  end
+
+  private
+
+  def self.normalize_number(value)
+    value&.zero? ? nil : value
+  end
+end

--- a/recruitment_qualification_test-main/app/services/listing_data.rb
+++ b/recruitment_qualification_test-main/app/services/listing_data.rb
@@ -1,0 +1,25 @@
+class ListingData
+  attr_reader :title, :start_time, :end_time, :description, :image_url, :episode_number, :season_number
+
+  def initialize(title:, start_time:, end_time:, description:, image_url:, episode_number: nil, season_number: nil)
+    @title = title
+    @start_time = start_time
+    @end_time = end_time
+    @description = description
+    @image_url = image_url
+    @episode_number = episode_number
+    @season_number = season_number
+  end
+
+  def to_h
+    {
+      title: title,
+      start_time: start_time,
+      end_time: end_time,
+      description: description,
+      image_url: image_url,
+      episode_number: episode_number,
+      season_number: season_number
+    }
+  end
+end

--- a/recruitment_qualification_test-main/app/services/xml_parser_service.rb
+++ b/recruitment_qualification_test-main/app/services/xml_parser_service.rb
@@ -1,30 +1,25 @@
-class XmlParserService
-  attr_reader :data
-
+class XmlParserService < BaseParserService
   # Service initiates with the file content of spec/fixtures/data.xml
-  def initialize(data)
-    @data = data
-  end
 
-  def parse
+  private
+
+  def extract_listings
     document = Nokogiri::XML(data)
     
-    document.xpath("//listing").each do |listing|
+    document.xpath("//listing").map do |listing|
       date = listing.attribute('date').value
       start_time_str = listing.attribute('start').value
       stop_time_str = listing.attribute('stop').value
       
-      start_time = parse_cet_to_utc(date, start_time_str)
-      end_time = parse_cet_to_utc(date, stop_time_str)
-      
+      # Extract episode information from episode node
       episode_node = listing.xpath('episode').first
       episode_number = episode_node&.text&.to_i
       season_number = episode_node&.attribute('season')&.value&.to_i
       
-      Listing.create!(
+      ListingData.new(
         title: listing.xpath('title').text,
-        start_time: start_time,
-        end_time: end_time,
+        start_time: parse_cet_to_utc(date, start_time_str),
+        end_time: parse_cet_to_utc(date, stop_time_str),
         description: listing.xpath('description').text,
         image_url: listing.xpath('image').text,
         episode_number: episode_number,
@@ -32,9 +27,7 @@ class XmlParserService
       )
     end
   end
-  
-  private
-  
+
   def parse_cet_to_utc(date, time)
     # CET is UTC+1, so we need to subtract 1 hour to get UTC
     datetime_str = "#{date}T#{time}+01:00"


### PR DESCRIPTION
- Extract BaseParserService to eliminate code duplication
- Create ListingData value object for consistent data structure
- Implement ListingCreator for centralized listing creation logic
- Refactor JSON and XML parsers to focus on data extraction only
- Improve maintainability and testability through separation of concerns
- All tests passing (9/9)